### PR TITLE
[FPGA] Update matmul sample to use annotated_arg

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/invocation_interfaces/src/register_map_functor_model.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/invocation_interfaces/src/register_map_functor_model.cpp
@@ -4,6 +4,8 @@
 
 #include "exception_handler.hpp"
 
+using namespace sycl::ext::oneapi::experimental;
+
 using ValueT = int;
 
 // offloaded computation
@@ -14,14 +16,15 @@ ValueT SomethingComplicated(ValueT val) { return (ValueT)(val * (val + 1)); }
 struct FunctorRegisterMapIP {
   // Use the 'register_map' annotation on a kernel argument to specify it to be
   // a register map kernel argument.
-  register_map ValueT *input;
+  annotated_arg<ValueT, decltype(properties{register_map})> input;
   // Without the annotations, kernel arguments will be inferred to be register
   // map kernel arguments if the kernel invocation interface is register mapped,
   // and vise-versa.
   ValueT *output;
   // A kernel with a register map invocation interface can also independently
   // have streaming kernel arguments, when annotated by 'conduit'.
-  conduit size_t n;
+  annotated_arg<size_t, decltype(properties{conduit})> n;
+
   register_map_interface void operator()() const {
     for (int i = 0; i < n; i++) {
       output[i] = SomethingComplicated(input[i]);

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/invocation_interfaces/src/streaming_functor_model.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/invocation_interfaces/src/streaming_functor_model.cpp
@@ -4,6 +4,8 @@
 
 #include "exception_handler.hpp"
 
+using namespace sycl::ext::oneapi::experimental;
+
 using ValueT = int;
 
 // offloaded computation
@@ -14,10 +16,10 @@ ValueT SomethingComplicated(ValueT val) { return (ValueT)(val * (val + 1)); }
 struct FunctorStreamingIP {
   // Use the 'conduit' annotation on a kernel argument to specify it to be
   // a streaming kernel argument.
-  conduit ValueT *input;
+  annotated_arg<ValueT *, decltype(properties{conduit})> input;
   // A kernel with a streaming invocation interface can also independently
   // have register map kernel arguments, when annotated by 'register_map'.
-  register_map ValueT *output;
+  annotated_arg<ValueT *, decltype(properties{register_map})> output;
   // Without the annotations, kernel arguments will be inferred to be streaming
   // kernel arguments if the kernel invocation interface is streaming, and
   // vise-versa.

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/pipelined_kernels/src/pipelined_kernels.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/pipelined_kernels/src/pipelined_kernels.cpp
@@ -4,13 +4,16 @@
 
 #include "exception_handler.hpp"
 
+using namespace sycl::ext::oneapi::experimental;
+
 using ValueT = int;
 
 // offloaded computation
 ValueT SomethingComplicated(ValueT val) { return (ValueT)(val * (val + 1)); }
 
 struct MyIP {
-  conduit ValueT *input;
+  annotated_arg<ValueT *, decltype(properties{conduit})> input;
+
   streaming_pipelined_interface void operator()() const {
     ValueT temp = *input;
     *input = SomethingComplicated(temp);


### PR DESCRIPTION
# Existing Sample Changes
## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes Issue# 

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
