### PR TITLE
Update sample matmul

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/matmul/src/memory_transfers.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/matmul/src/memory_transfers.hpp
@@ -43,7 +43,7 @@ public:
          1,      // read_write_mode, 0: ReadWrite, 1: Read, 2: Write
          1,      // maxburst
          0,      // align, 0 defaults to alignment of the type
-         1)      // waitrequest, 0: false, 1: true
+         0)      // waitrequest, 0: false, 1: true
 #endif
       TT *a_ptr;   // Input matrix pointer
   int repetitions; // Number of times to write the same matrix to the pipe
@@ -196,7 +196,7 @@ public:
          1,      // read_write_mode, 0: ReadWrite, 1: Read, 2: Write
          1,      // maxburst
          0,      // align, 0 defaults to alignment of the type
-         1)      // waitrequest, 0: false, 1: true
+         0)      // waitrequest, 0: false, 1: true
 #endif
       TT *b_ptr;   // Input matrix pointer
   int repetitions; // Number of times to write the same matrix to the pipe
@@ -341,7 +341,7 @@ public:
          2,      // read_write_mode, 0: ReadWrite, 1: Read, 2: Write
          1,      // maxburst
          0,      // align, 0 defaults to alignment of the type
-         1)      // waitrequest, 0: false, 1: true
+         0)      // waitrequest, 0: false, 1: true
 #endif
       TT *c_ptr;   // Output matrix pointer
   int repetitions; // Number of time to read the same matrix to the pipe


### PR DESCRIPTION
# Existing Sample Changes
## Description

1. Update the mmhost parameterization in the `matmul` sample, as the compiler no longer allow `waitrequest=1`  when  latency>0.
2. Change the macro-style annotation to `annotated_arg` class

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used