### PR TITLE
[FPGA] Update zero_copy_kernel sample to support IP-Authoring

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/buffer_kernel.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/buffer_kernel.hpp
@@ -33,11 +33,12 @@ double SubmitBufferKernel(queue& q, std::vector<T>& in, std::vector<T>& out,
       accessor in_a(in_buf, h, read_only);
       accessor out_a(out_buf, h, write_only, no_init);
 #else
-      // When targeting an FPGA family/part, the compiler does not know
-      // if the two kernels accesses the same memory location
+      // When targeting an FPGA family/part, the compiler infers memory
+      // interfaces based on the unique buffer_location property specified
+      // on kernel arguments
       // With this property, we tell the compiler that these buffers
-      // are in a location "1" whereas the pointers from ExplicitKernel
-      // are in the default location "0"
+      // are in a location "1" whereas the pointers from ZeroCopyKernel
+      // are in the location "0"
       sycl::ext::oneapi::accessor_property_list location_of_buffer{
           ext::intel::buffer_location<1>};
       accessor in_a(in_buf, h, read_only, location_of_buffer);

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/zero_copy_data_transfer.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/zero_copy_data_transfer.cpp
@@ -83,12 +83,9 @@ int main(int argc, char* argv[]) {
     Type* in_zero_copy = malloc_host<Type>(size, q.get_context());
     Type* out_zero_copy = malloc_host<Type>(size, q.get_context());
 #else
-    // When targeting an FPGA family/part, the compiler infers memory
-    // interfaces based on the unique buffer_location property specified
-    // on kernel arguments
-    // The USM pointers passed into the kernel must match with the buffer location
-    // of each kernel argument, i.e. the allocated host memory should be in
-    // the location "0", as requested in ZeroCopyKernel
+    // The USM pointers passed into the kernel must be allocated with the same
+    // buffer_location as the one specified on the kernel argument with the
+    // annotated_arg class.
     Type *in_zero_copy = sycl::malloc_host<Type>(
         size, q,
         sycl::ext::intel::experimental::property::usm::buffer_location(0));

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/zero_copy_data_transfer.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/zero_copy_data_transfer.cpp
@@ -83,6 +83,12 @@ int main(int argc, char* argv[]) {
     Type* in_zero_copy = malloc_host<Type>(size, q.get_context());
     Type* out_zero_copy = malloc_host<Type>(size, q.get_context());
 #else
+    // When targeting an FPGA family/part, the compiler infers memory
+    // interfaces based on the unique buffer_location property specified
+    // on kernel arguments
+    // The USM pointers passed into the kernel must match with the buffer location
+    // of each kernel argument, i.e. the allocated host memory should be in
+    // the location "0", as requested in ZeroCopyKernel
     Type *in_zero_copy = sycl::malloc_host<Type>(
         size, q,
         sycl::ext::intel::experimental::property::usm::buffer_location(0));

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/zero_copy_data_transfer.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/zero_copy_data_transfer.cpp
@@ -79,8 +79,17 @@ int main(int argc, char* argv[]) {
 
     // input and output data for the zero-copy version
     // malloc_host allocates memory specifically in the host's address space
+#if defined(IS_BSP)
     Type* in_zero_copy = malloc_host<Type>(size, q.get_context());
     Type* out_zero_copy = malloc_host<Type>(size, q.get_context());
+#else
+    Type *in_zero_copy = sycl::malloc_host<Type>(
+        size, q,
+        sycl::ext::intel::experimental::property::usm::buffer_location(0));
+    Type *out_zero_copy = sycl::malloc_host<Type>(
+        size, q,
+        sycl::ext::intel::experimental::property::usm::buffer_location(0));
+#endif
     
     // ensure that we could allocate space for both the input and output
     if (in_zero_copy == NULL) {

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/zero_copy_kernel.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/zero_copy_kernel.hpp
@@ -61,6 +61,12 @@ using ConsumePipe = pipe<class ConsumePipeClass, T>;
 template <typename T>
 event SubmitProducer(queue& q, T* in_data, size_t size) {
 #if !defined(IS_BSP)
+  // When targeting an FPGA family/part, the compiler infers memory
+  // interfaces based on the unique buffer_location property specified
+  // on kernel arguments
+  // With this property, we tell the compiler that these buffers
+  // are in a location "0" whereas the pointers from BufferKernel
+  // are in the location "1"
   sycl::ext::oneapi::experimental::annotated_arg h_in_data(
       in_data, sycl::ext::oneapi::experimental::properties{
               sycl::ext::intel::experimental::buffer_location<0>});

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/zero_copy_kernel.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/zero_copy_kernel.hpp
@@ -110,6 +110,12 @@ event SubmitWorker(queue& q, size_t size) {
 template <typename T>
 event SubmitConsumer(queue& q, T* out_data, size_t size) {
 #if !defined(IS_BSP)
+  // When targeting an FPGA family/part, the compiler infers memory
+  // interfaces based on the unique buffer_location property specified
+  // on kernel arguments
+  // With this property, we tell the compiler that these buffers
+  // are in a location "0" whereas the pointers from BufferKernel
+  // are in the location "1"
   sycl::ext::oneapi::experimental::annotated_arg h_out_data(
       out_data, sycl::ext::oneapi::experimental::properties{
               sycl::ext::intel::experimental::buffer_location<0>});


### PR DESCRIPTION
## Description
This change updates `zero_copy_kernel` sample on how the buffer locations are being selected in the sample to match the new 2024.0 IPA interfaces definitions.
In `zero_copy_kernel` both accessor (requiring device allcoated memory) and USM host pointer are used. In full-system flow, the board spec has defined a device global memory and a host/shared global memory. While in IP-Authoring flow, `buffer_location` should be specified on `accessor` and `annotated_arg` so the compiler can infer global memory interfaces and generate board spec.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used