### PR TITLE
Add utility function for annotated malloc

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/mm-host/src/vector_add.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/mm-host/src/vector_add.cpp
@@ -102,9 +102,10 @@ int main() {
 
     // Allocate USM shared memory using the utility function `alloc_annotated`
     // (defined in "annotated_class_util.hpp"), which takes an annotated_arg
-    // type as the template parameter. This ensures the properties of the
-    // returned memory (e.g. buffer location, alignment) matches with the
-    // annotations on the kernel arguments
+    // type as the template parameter and returns an instance of such
+    // annotated_arg. This ensures the properties of the returned memory
+    // (e.g. buffer location, alignment) match with the annotations on the
+    // kernel arguments
     auto c = fpga_tools::alloc_annotated<karg_c_t>(count, q);
 
     for (int i = 0; i < count; i++) {

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/mmhost/part3_hosts/src/mmhost.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/mmhost/part3_hosts/src/mmhost.cpp
@@ -1,12 +1,24 @@
 #include <sycl/ext/intel/fpga_extensions.hpp>
 #include <sycl/sycl.hpp>
 
+#include "annotated_class_util.hpp"
 #include "exception_handler.hpp"
 
 constexpr int kBL1 = 1;
 constexpr int kBL2 = 2;
 constexpr int kBL3 = 3;
 constexpr int kAlignment = 4;
+
+// Create type alias for the type of kernel argument `z`, so it can be
+// reused in the annotated memory allocation in the host code
+using karg_z_t = sycl::ext::oneapi::experimental::annotated<
+    int *, decltype(sycl::ext::oneapi::experimental::properties{
+               sycl::ext::intel::experimental::buffer_location<kBL3>,
+               sycl::ext::intel::experimental::awidth<32>,
+               sycl::ext::intel::experimental::dwidth<32>,
+               sycl::ext::intel::experimental::latency<1>,
+               sycl::ext::oneapi::experimental::alignment<kAlignment>,
+               sycl::ext::intel::experimental::read_write_mode_write})>;
 
 struct MultiMMIP {
   // Each annotated pointer is configured with a unique `buffer_location`,
@@ -25,17 +37,10 @@ struct MultiMMIP {
       sycl::ext::intel::experimental::latency<1>,
       sycl::ext::oneapi::experimental::alignment<kAlignment>,
       sycl::ext::intel::experimental::read_write_mode_read});
-  using ZProps = decltype(sycl::ext::oneapi::experimental::properties{
-      sycl::ext::intel::experimental::buffer_location<kBL3>,
-      sycl::ext::intel::experimental::awidth<32>,
-      sycl::ext::intel::experimental::dwidth<32>,
-      sycl::ext::intel::experimental::latency<1>,
-      sycl::ext::oneapi::experimental::alignment<kAlignment>,
-      sycl::ext::intel::experimental::read_write_mode_write});
 
   sycl::ext::oneapi::experimental::annotated_arg<int *, XProps> x;
   sycl::ext::oneapi::experimental::annotated_arg<int *, YProps> y;
-  sycl::ext::oneapi::experimental::annotated_arg<int *, ZProps> z;
+  karg_z_t z;
 
   int size;
 
@@ -81,7 +86,14 @@ int main(void) {
     int *array_b = sycl::aligned_alloc_shared<int>(
         kAlignment, kN, q,
         sycl::ext::intel::experimental::property::usm::buffer_location(kBL2));
-    int *array_c = sycl::aligned_alloc_shared<int>(
+
+    // Allocate USM shared memory using the utility function `alloc_annotated`
+    // (defined in "annotated_class_util.hpp"), which takes an annotated_arg
+    // type as the template parameter and returns an instance of such
+    // annotated_arg. This ensures the properties of the returned memory
+    // (e.g. buffer location, alignment) match with the annotations on the
+    // kernel arguments
+    auto array_c = fpga_tools::alloc_annotated<karg_z_t>(
         kAlignment, kN, q,
         sycl::ext::intel::experimental::property::usm::buffer_location(kBL3));
 

--- a/DirectProgramming/C++SYCL_FPGA/include/annotated_class_util.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/include/annotated_class_util.hpp
@@ -1,8 +1,51 @@
+#ifndef __ANNOTATED_CLASS_UTIL_HPP__
+#define __ANNOTATED_CLASS_UTIL_HPP__
+
 #include <sycl/sycl.hpp>
 
 using namespace sycl::ext::oneapi::experimental;
 
 namespace fpga_tools {
+///////////////////////////////////////////////////////////////////////////////
+// This header provides a utility function: "alloc_annotated", which improves
+// malloc_shared" in allocating host/share memory in the following aspects:
+//   (1) better code brevity
+//   (2) support compile-time type check
+//
+// "annotated_alloc" function takes an annotated_arg type as the only template
+// parameter, and returns an instance of that annotated_arg type. This provides
+// compile-time guarantee that the properties of the allocated memory (e.g.
+// buffer location, alignment) match with the annotations on the kernel arguments
+//
+// To use "alloc_annotated",
+//
+// 1. include header "annotated_class_util.hpp"
+// 2. create a type alias for the "annotated_arg" type, e.g.
+//
+//    using karg_t = sycl::ext::oneapi::experimental::annotated_arg<
+//        int *, decltype(sycl::ext::oneapi::experimental::properties{
+//                        sycl::ext::intel::experimental::buffer_location<1>,
+//                        sycl::ext::intel::experimental::dwidth<32>,
+//                        sycl::ext::intel::experimental::latency<0>,
+//                        sycl::ext::intel::experimental::read_write_mode_write,
+//                        sycl::ext::oneapi::experimental::alignment<4>})>;
+//
+// Specifically, if "-std=c++20" is supported, the type alias declaration above
+// can be symplified as:
+//
+//    using karg_t = sycl::ext::oneapi::experimental::annotated_arg<
+//                  int *, fpga_tools::properties_t<
+//                    sycl::ext::intel::experimental::buffer_location<1>,
+//                    sycl::ext::intel::experimental::dwidth<32>,
+//                    sycl::ext::intel::experimental::latency<0>,
+//                    sycl::ext::intel::experimental::read_write_mode_write,
+//                    sycl::ext::oneapi::experimental::alignment<4>>;
+//
+// 3. in the host code, replace the "malloc_shared" call by:
+//
+//    auto c = fpga_tools::alloc_annotated<karg_t>(count, q);
+//
+///////////////////////////////////////////////////////////////////////////////
 
 #if __cplusplus >= 202002L
 

--- a/DirectProgramming/C++SYCL_FPGA/include/annotated_class_util.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/include/annotated_class_util.hpp
@@ -1,0 +1,110 @@
+#include <sycl/sycl.hpp>
+
+using namespace sycl::ext::oneapi::experimental;
+
+namespace fpga_tools {
+
+#if __cplusplus >= 202002L
+
+template <auto... Props> using properties_t = decltype(properties{Props...});
+
+#endif
+
+// Type traits to check if a type is annotated_ptr or
+// annotated_arg
+template <typename T> struct is_annotated_class : std::false_type {};
+
+template <typename T, typename... Props>
+struct is_annotated_class<annotated_ptr<T, detail::properties_t<Props...>>>
+    : std::true_type {};
+
+template <typename T, typename... Props>
+struct is_annotated_class<annotated_arg<T, detail::properties_t<Props...>>>
+    : std::true_type {};
+
+// Type traits to get the underlying raw type of annotated_arg/annotated_ptr
+template <typename T> struct get_raw_type {};
+
+template <typename T, typename... Props>
+struct get_raw_type<annotated_ptr<T, detail::properties_t<Props...>>> {
+  using type = T;
+};
+
+template <typename T, typename... Props>
+struct get_raw_type<annotated_arg<T, detail::properties_t<Props...>>> {
+  static constexpr bool is_annotated_arg_for_pointer = false;
+  static_assert(is_annotated_arg_for_pointer,
+                "'alloc_annotated' cannot be specified with annotated_arg<T> "
+                "as template parameter if T is a non-pointer type");
+};
+
+template <typename T, typename... Props>
+struct get_raw_type<annotated_arg<T *, detail::properties_t<Props...>>> {
+  using type = T;
+};
+
+// Type traits to get the type of the property list in
+// annotated_arg/annotated_ptr
+template <typename T> struct get_property_list {};
+
+template <typename T, typename... Props>
+struct get_property_list<annotated_ptr<T, detail::properties_t<Props...>>> {
+  using type = detail::properties_t<Props...>;
+};
+
+template <typename T, typename... Props>
+struct get_property_list<annotated_arg<T, detail::properties_t<Props...>>> {
+  using type = detail::properties_t<Props...>;
+};
+
+// Type traits to remove alignment from a property list. This is needed for
+// because the annotated malloc API does not support compile-time alignment
+// property
+template <typename T> struct remove_align_from {};
+
+template <> struct remove_align_from<detail::empty_properties_t> {
+  using type = detail::empty_properties_t;
+};
+
+template <typename Prop, typename... Props>
+struct remove_align_from<detail::properties_t<Prop, Props...>> {
+  using type = std::conditional_t<
+      detail::HasAlign<detail::properties_t<Prop>>::value,
+      detail::properties_t<Props...>,
+      detail::merged_properties_t<
+          detail::properties_t<Prop>,
+          typename remove_align_from<detail::properties_t<Props...>>::type>>;
+};
+
+template <typename T> struct split_annotated_type {
+  static constexpr bool is_valid_annotated_type = is_annotated_class<T>::value;
+  static_assert(is_valid_annotated_type,
+                "alloc_annotated function only takes 'annotated_ptr' or "
+                "'annotated_arg' type as a template parameter");
+
+  using raw_type = typename get_raw_type<T>::type;
+  using all_properties = typename get_property_list<T>::type;
+  static constexpr size_t alignment =
+      detail::GetAlignFromPropList<all_properties>::value;
+  using properties = typename remove_align_from<all_properties>::type;
+};
+
+// Wrapper function that allocates USM host memory with compile-time properties
+// and returns annotated_ptr
+template <typename T>
+T alloc_annotated(size_t count, const sycl::queue &syclQueue,
+                  sycl::usm::alloc usmKind = sycl::usm::alloc::host) {
+  auto ann_ptr =
+      aligned_alloc_annotated<typename split_annotated_type<T>::raw_type,
+                              typename split_annotated_type<T>::properties>(
+          split_annotated_type<T>::alignment, count, syclQueue, usmKind);
+
+  if (ann_ptr.get() == nullptr) {
+    std::cerr << "Memory allocation returns null" << std::endl;
+    std::terminate();
+  }
+
+  return T{ann_ptr.get()};
+}
+
+} // namespace fpga_tools

--- a/DirectProgramming/C++SYCL_FPGA/include/annotated_class_util.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/include/annotated_class_util.hpp
@@ -8,42 +8,47 @@ using namespace sycl::ext::oneapi::experimental;
 namespace fpga_tools {
 ///////////////////////////////////////////////////////////////////////////////
 // This header provides a utility function: "alloc_annotated", which improves
-// malloc_shared" in allocating host/share memory in the following aspects:
+// "malloc_shared" in allocating host/share memory in the following aspects:
 //   (1) better code brevity
 //   (2) support compile-time type check
 //
 // "annotated_alloc" function takes an annotated_arg type as the only template
-// parameter, and returns an instance of that annotated_arg type. This provides
-// compile-time guarantee that the properties of the allocated memory (e.g.
-// buffer location, alignment) match with the annotations on the kernel arguments
+// parameter, and returns an instance of that annotated_arg's template type. This provides
+// a compile-time guarantee that the properties of the allocated memory (for example,
+// buffer location, alignment) match with the annotations on the kernel arguments.
 //
 // To use "alloc_annotated",
 //
 // 1. include header "annotated_class_util.hpp"
 // 2. create a type alias for the "annotated_arg" type, e.g.
 //
-//    using karg_t = sycl::ext::oneapi::experimental::annotated_arg<
-//        int *, decltype(sycl::ext::oneapi::experimental::properties{
-//                        sycl::ext::intel::experimental::buffer_location<1>,
-//                        sycl::ext::intel::experimental::dwidth<32>,
-//                        sycl::ext::intel::experimental::latency<0>,
-//                        sycl::ext::intel::experimental::read_write_mode_write,
-//                        sycl::ext::oneapi::experimental::alignment<4>})>;
+//  using annotated_arg_t =
+//      sycl::ext::oneapi::experimental::annotated_arg<
+//          int *, decltype(sycl::ext::oneapi::experimental::properties{
+//                          sycl::ext::intel::experimental::buffer_location<1>,
+//                          sycl::ext::intel::experimental::dwidth<32>,
+//                          sycl::ext::intel::experimental::latency<0>,
+//                          sycl::ext::intel::experimental::read_write_mode_write,
+//                          sycl::ext::oneapi::experimental::alignment<4>})>;
 //
-// Specifically, if "-std=c++20" is supported, the type alias declaration above
-// can be symplified as:
+// Furthermore, if you add the "-std=c++20" compiler flag, the type alias declaration above
+// can be simplified as:
 //
-//    using karg_t = sycl::ext::oneapi::experimental::annotated_arg<
-//                  int *, fpga_tools::properties_t<
-//                    sycl::ext::intel::experimental::buffer_location<1>,
-//                    sycl::ext::intel::experimental::dwidth<32>,
-//                    sycl::ext::intel::experimental::latency<0>,
-//                    sycl::ext::intel::experimental::read_write_mode_write,
-//                    sycl::ext::oneapi::experimental::alignment<4>>;
+//  using annotated_arg_t = sycl::ext::oneapi::experimental::annotated_arg<
+//      int *, fpga_tools::properties_t<
+//                  sycl::ext::intel::experimental::buffer_location<1>,
+//                  sycl::ext::intel::experimental::dwidth<32>,
+//                  sycl::ext::intel::experimental::latency<0>,
+//                  sycl::ext::intel::experimental::read_write_mode_write,
+//                  sycl::ext::oneapi::experimental::alignment<4>>;
 //
 // 3. in the host code, replace the "malloc_shared" call by:
 //
-//    auto c = fpga_tools::alloc_annotated<karg_t>(count, q);
+//  annotated_arg_t c = fpga_tools::alloc_annotated<annotated_arg_t>(count, q);
+//
+//
+// NOTE: "annotated_alloc" function only takes annotated_ptr or annotated_arg with
+// pointer type as valid template parameter. Other types cause a compiler error.
 //
 ///////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
# Add utility function `alloc_annotated`
## Description

Create utility function `alloc_annotated` in a common header "annotated_class_util.hpp" to improve the code brevity and support compile-time type check. The new function takes an annotated_arg type as the template parameter and returns an instance of that annotated_arg type. This ensures the properties of the returned memory (e.g. buffer location, alignment) match with the annotations on the kernel arguments

Code samples under `hls_flow_interfaces/` using annotated_arg are updated to partially use the new utility function.

An example of using the utility function is
```
// Create type alias for the annotated_arg type
using karg_c_t = sycl::ext::oneapi::experimental::annotated_arg<
      int *, decltype(sycl::ext::oneapi::experimental::properties{
                 sycl::ext::intel::experimental::buffer_location<kBL3>,
                 sycl::ext::intel::experimental::dwidth<32>,
                 sycl::ext::intel::experimental::latency<0>,
                 sycl::ext::intel::experimental::read_write_mode_write,
                 sycl::ext::oneapi::experimental::alignment<4>})>;

// in host code, call the utility function to get the annotated_arg instance
auto c = fpga_tools::alloc_annotated<karg_c_t>(count, q);
```
## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
